### PR TITLE
readme: add link to contour plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ All plugins have been vetted and approved by the Loft team.
 
 Plugins:
 - [`cert-manager-plugin`](https://github.com/loft-sh/vcluster-plugins/tree/master/cert-manager-plugin): Reuse the host cluster's [cert-manager](https://cert-manager.io/docs/) inside vcluster. Syncs issuers and certificates to vcluster 
+
+- [`deeplay-io/vcluster-contour-sync-plugin`](https://github.com/deeplay-io/vcluster-contour-sync-plugin): This plugin syncs Contour resources from the virtual cluster to the host cluster. It expects that Contour CRDs were already installed in the host cluster.


### PR DESCRIPTION
:tada: Adding https://github.com/deeplay-io/vcluster-contour-sync-plugin to the plugin list in the Readme on behalf of community contributors.