### PR TITLE
feat: basic implementation of the syncBack

### DIFF
--- a/generic-crd-plugin/.vscode/launch.json
+++ b/generic-crd-plugin/.vscode/launch.json
@@ -9,6 +9,7 @@
       "type": "go",
       "request": "attach",
       "mode": "remote",
+      "debugAdapter": "dlv-dap",
       "port": 2346,
       "host": "localhost",
       "substitutePath": [

--- a/generic-crd-plugin/devspace.yaml
+++ b/generic-crd-plugin/devspace.yaml
@@ -34,25 +34,16 @@ deployments:
             env:
               # Config for testing
               # run `make install-cert-manager` within the host kube context before using
+              # Then in vcluster context create hack/selfsigned-issuer.yaml
+              # and hack/generate-dummy-certificate.yaml
+              #
+              # For convenience export config inside the dev container from the hack/test-config.yaml
+              # export CONFIG=$(cat hack/test-config.yaml)
               - name: CONFIG
                 value: |-
                   version: v1beta1
-                  mappings:
-                    - fromVirtualCluster:
-                        apiVersion: cert-manager.io/v1
-                        kind: Certificate
-                        patches:
-                          - type: rewriteName
-                            path: spec.issuerRef.name
-                        reversePatches:
-                          - type: copyFromObject
-                            fromPath: status
-                            path: status
-                          - type: copyFromObject
-                            fromPath: spec.issuerRef.name
-                            path: metadata.annotations['test.loft.sh/issuerRefName']
-                          - type: rewriteName
-                            path: metadata.annotations['test.loft.sh/issuerRefName']
+                  mappings: []
+
         syncer:
           readinessProbe:
             enabled: false

--- a/generic-crd-plugin/devspace_start.sh
+++ b/generic-crd-plugin/devspace_start.sh
@@ -4,8 +4,8 @@ set +e  # Continue on errors
 COLOR_CYAN="\033[0;36m"
 COLOR_RESET="\033[0m"
 
-RUN_CMD="go run -mod vendor main.go"
-DEBUG_CMD="dlv debug ./main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\""
+RUN_CMD="export CONFIG=\$(cat hack/test-config.yaml) && go run -mod vendor main.go"
+DEBUG_CMD="export CONFIG=\$(cat hack/test-config.yaml) && dlv debug ./main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\""
 
 echo -e "${COLOR_CYAN}
    ____              ____

--- a/generic-crd-plugin/go.mod
+++ b/generic-crd-plugin/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/loft-sh/vcluster-sdk v0.2.0
+	github.com/loft-sh/vcluster-sdk v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	github.com/wI2L/jsondiff v0.2.0

--- a/generic-crd-plugin/go.sum
+++ b/generic-crd-plugin/go.sum
@@ -346,6 +346,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/loft-sh/vcluster-sdk v0.2.0 h1:d1uyWMZVcfFso7umN1W+ghLohv8LPLUbO8dSMgeRoVo=
 github.com/loft-sh/vcluster-sdk v0.2.0/go.mod h1:HdQ75vqJuqiHiCtX+bmRAN9ZrCFimeYfQ5vKX1hEx2o=
+github.com/loft-sh/vcluster-sdk v0.3.0 h1:/934jIw+kfpXS7ujX6pt4pDi06MiWyKY7S+Q7kI37Z4=
+github.com/loft-sh/vcluster-sdk v0.3.0/go.mod h1:HdQ75vqJuqiHiCtX+bmRAN9ZrCFimeYfQ5vKX1hEx2o=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/generic-crd-plugin/hack/selfsigned-issuer.yaml
+++ b/generic-crd-plugin/hack/selfsigned-issuer.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: selfsigned-issuer
+  name: selfsigned-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab
   namespace: default
   labels:
     test: first

--- a/generic-crd-plugin/hack/test-config.yaml
+++ b/generic-crd-plugin/hack/test-config.yaml
@@ -1,0 +1,45 @@
+version: v1beta1
+mappings:
+  - fromVirtualCluster:
+      # CRD for the apiVersion+Kind is implicitly copied to the virtual cluster
+      apiVersion: cert-manager.io/v1
+      kind: Issuer
+      patches: []
+      reversePatches: []
+  - fromVirtualCluster:
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      # Virtual -> Host Cluster patches
+      patches:
+        - type: rewriteName
+          path: spec.issuerRef.name
+        - type: rewriteName
+          path: spec.secretName
+      # Host -> Virtual Cluster patches
+      reversePatches:
+        - type: copyFromObject
+          fromPath: status
+          path: status
+        - type: copyFromObject
+          fromPath: spec.issuerRef.name
+          path: metadata.annotations['test.loft.sh/issuerRefName']
+        - type: rewriteName
+          path: metadata.annotations['test.loft.sh/issuerRefName']
+          fromPath: spec.issuerRef.name
+      syncBack:
+        - kind: Secret
+          apiVersion: v1
+          selectors:
+            - name:
+                rewrittenPath: spec.secretName
+          # Host -> Virtual Cluster patches
+          patches: [] 
+            # Implicit
+            # - op: rewriteName
+            #   path: metadata.name
+            #   from: metadata.name # Host name to virtual cluster name
+            # - op: rewriteNamespace
+            #   path: metadata.namespace
+            #   from: metadata.namespace # Host name to virtual cluster name
+          # Virtual -> Host Cluster patches
+          reversePatches: []

--- a/generic-crd-plugin/pkg/config/config.go
+++ b/generic-crd-plugin/pkg/config/config.go
@@ -18,23 +18,51 @@ type Mapping struct {
 	FromVirtualCluster *FromVirtualCluster `yaml:"fromVirtualCluster,omitempty" json:"fromVirtualCluster,omitempty"`
 }
 
-type FromVirtualCluster struct {
+type SyncBase struct {
 	TypeInformation `yaml:",inline" json:",inline"`
+
+	// Patches are the patches to apply on the virtual cluster objects
+	// when syncing them from the host cluster
+	Patches []*Patch `yaml:"patches,omitempty" json:"patches,omitempty"`
+
+	// ReversePatches are the patches to apply to host cluster objects
+	// after it has been synced to the virtual cluster
+	ReversePatches []*Patch `yaml:"reversePatches,omitempty" json:"reversePatches,omitempty"`
+}
+
+type FromVirtualCluster struct {
+	SyncBase `yaml:",inline" json:",inline"`
 
 	// Selector is the selector to select the objects in the host cluster.
 	// If empty will select all objects.
 	Selector *Selector `yaml:"selector,omitempty" json:"selector,omitempty"`
 
-	// Patches are the patches to apply on the host cluster objects before
-	// syncing it to the host cluster
-	Patches []*Patch `yaml:"patches,omitempty" json:"patches,omitempty"`
+	// Resources to sync back to virtual cluster
+	SyncBack []*SyncBack `yaml:"syncBack,omitempty" json:"syncBack,omitempty"`
+}
 
-	// ReversePatches are
-	ReversePatches []*Patch `yaml:"reversePatches,omitempty" json:"reversePatches,omitempty"`
+type SyncBack struct {
+	SyncBase `yaml:",inline" json:",inline"`
+
+	// Selectors are the SyncBackSelector definitions to select the objects
+	// in the host cluster thatwill be synced to the virtual cluster
+	// If empty will select all objects.
+	Selectors []*SyncBackSelector `yaml:"selectors,omitempty" json:"selectors,omitempty"`
+}
+
+type SyncBackSelector struct {
+	// Select object to sync based on its .metadata.name
+	Name *NameSyncBackSelector `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+type NameSyncBackSelector struct {
+	// Path to a field of parent sync object that references name of the resources
+	// that we wish to sync back to the virtual cluster
+	RewrittenPath string `yaml:"rewrittenPath,omitempty" json:"rewrittenPath,omitempty"`
 }
 
 type FromHostCluster struct {
-	TypeInformation `yaml:",inline" json:",inline"`
+	SyncBase `yaml:",inline" json:",inline"`
 
 	// NameMapping defines how objects will be mapped between host and
 	// virtual cluster.
@@ -43,9 +71,6 @@ type FromHostCluster struct {
 	// Selector is the selector to select the objects in the host cluster.
 	// If empty will select all objects.
 	Selector *Selector `yaml:"selector,omitempty" json:"selector,omitempty"`
-
-	// Patches are the patches to apply on the host cluster objects
-	Patches []*Patch `yaml:"patches,omitempty" json:"patches,omitempty"`
 }
 
 type TypeInformation struct {

--- a/generic-crd-plugin/pkg/namecache/from_host_handler.go
+++ b/generic-crd-plugin/pkg/namecache/from_host_handler.go
@@ -1,10 +1,11 @@
 package namecache
 
 import (
+	"strings"
+
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
 )
 
 type fromHostClusterCacheHandler struct {
@@ -62,6 +63,7 @@ func (c *fromHostClusterCacheHandler) mappingsFromVirtualObject(obj *unstructure
 				mappings = append(mappings, mapping{
 					VirtualName: splitted[0],
 					HostName:    splitted[1],
+					// TODO: we probably need to add FieldPath here
 				})
 			}
 		}

--- a/generic-crd-plugin/pkg/namecache/from_virtual_handler.go
+++ b/generic-crd-plugin/pkg/namecache/from_virtual_handler.go
@@ -60,6 +60,7 @@ func (c *fromVirtualClusterCacheHandler) mappingsFromVirtualObject(obj *unstruct
 		{
 			VirtualName: obj.GetNamespace() + "/" + obj.GetName(),
 			HostName:    translate.PhysicalName(obj.GetName(), obj.GetNamespace()),
+			FieldPath:   MetadataFieldPath,
 		},
 	}
 
@@ -90,6 +91,7 @@ func (c *fromVirtualClusterCacheHandler) mappingsFromVirtualObject(obj *unstruct
 				mappings = append(mappings, mapping{
 					VirtualName: obj.GetNamespace() + "/" + m.Value,
 					HostName:    translate.PhysicalName(m.Value, obj.GetNamespace()),
+					FieldPath:   p.Path,
 				})
 			}
 		}

--- a/generic-crd-plugin/pkg/patches/patch_test.go
+++ b/generic-crd-plugin/pkg/patches/patch_test.go
@@ -192,7 +192,7 @@ test2: {}`,
 			assert.NilError(t, err, "error in node creation in test case %s", testCase.name)
 		}
 
-		err = ApplyPatch(obj1, obj2, testCase.patch, testCase.nameResolver)
+		err = applyPatch(obj1, obj2, testCase.patch, testCase.nameResolver)
 		assert.NilError(t, err, "error in applying patch in test case %s", testCase.name)
 
 		// compare output

--- a/generic-crd-plugin/pkg/syncer/back_syncer.go
+++ b/generic-crd-plugin/pkg/syncer/back_syncer.go
@@ -1,0 +1,298 @@
+package syncer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/config"
+	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/namecache"
+	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/patches"
+	"github.com/loft-sh/vcluster-sdk/syncer"
+	synccontext "github.com/loft-sh/vcluster-sdk/syncer/context"
+	"github.com/loft-sh/vcluster-sdk/syncer/translator"
+	"github.com/loft-sh/vcluster-sdk/translate"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	IndexByVirtualName = "indexbyvirtualname"
+)
+
+func CreateBackSyncer(ctx *synccontext.RegisterContext, config *config.SyncBack, parentConfig *config.FromVirtualCluster, parentNC namecache.NameCache) (syncer.Syncer, error) {
+	if len(config.Selectors) == 0 {
+		return nil, fmt.Errorf("the syncBack config for %s (%s) is missing Selectors", config.Kind, parentConfig.Kind)
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetKind(config.Kind)
+	obj.SetAPIVersion(config.ApiVersion)
+
+	// TODO: [low priority] check if config.Kind + config.ApiVersion has status subresource
+	statusIsSubresource := true
+
+	//  |
+	//  |
+	//  |
+	//  |
+	// \|/
+	// TODO: TOP priority - initialize a name cache for the translations done in the syncBack patches and reversePatches
+	nc := parentNC
+
+	return &backSyncController{
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, config.Kind+"-back-syncer", obj),
+
+		options:             ctx.Options,
+		physicalClient:      ctx.PhysicalManager.GetClient(),
+		config:              config,
+		parentConfig:        parentConfig,
+		namecache:           nc,
+		parentNamecache:     parentNC,
+		statusIsSubresource: statusIsSubresource,
+	}, nil
+}
+
+type backSyncController struct {
+	translator.NamespacedTranslator
+
+	options             *synccontext.VirtualClusterOptions
+	physicalClient      client.Client
+	config              *config.SyncBack
+	parentConfig        *config.FromVirtualCluster
+	namecache           namecache.NameCache
+	parentNamecache     namecache.NameCache
+	statusIsSubresource bool
+}
+
+var _ syncer.ControllerModifier = &backSyncController{}
+
+func (b *backSyncController) ModifyController(ctx *synccontext.RegisterContext, builder *builder.Builder) (*builder.Builder, error) {
+	// Setup a watch to receive a workqueue reference of the controller
+	// workqueue can then be used in the cache hooks to trigger a reconcile
+	// of this controller when a new entry for paths used by this syncer is added
+	return builder.Watches(b, &handler.EnqueueRequestForObject{}), nil
+}
+
+var _ syncer.Starter = &backSyncController{}
+
+func (b *backSyncController) ReconcileEnd() {}
+
+func (b *backSyncController) ReconcileStart(ctx *synccontext.SyncContext, req ctrl.Request) (bool, error) {
+	// check that VirtualToPhysical won't return empty name to avoid failing here:
+	// https://github.com/loft-sh/vcluster-sdk/blob/d1087161ef718af44d08eb8771f6358fb5624265/syncer/syncer.go#L85
+	pNN := b.VirtualToPhysical(req.NamespacedName, nil)
+	return pNN.Name == "", nil
+}
+
+func (b *backSyncController) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+func (b *backSyncController) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj client.Object) (ctrl.Result, error) {
+	ctx.Log.Infof("Sync() for pObj %s / vObj %s/%s", pObj.GetName(), vObj.GetNamespace(), vObj.GetName())
+
+	// TODO: test Sync patches and reversePatches after solving a TODO regarding initialization of the b.namecache
+	// Execute patches on virtual object
+	updatedVObj := vObj.DeepCopyObject().(client.Object)
+	result, err := executeObjectPatch(ctx.Context, ctx.VirtualClient, updatedVObj, func() error {
+		err := patches.ApplyPatches(updatedVObj, pObj, b.config.Patches, &hostToVirtualNameResolver{namecache: b.namecache})
+		if err != nil {
+			return fmt.Errorf("error applying patches: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		if kerrors.IsInvalid(err) {
+			ctx.Log.Infof("Warning: this message could indicate a timing issue with no significant impact, or a bug. Please report this if your resource never reaches the expected state. Error message: failed to patch virtual %s %s/%s: %v", b.config.Kind, vObj.GetNamespace(), vObj.GetName(), err)
+			// this happens when some field is being removed shortly after being added, which suggest it's a timing issue
+			// it doesn't seem to have any negative consequence besides the logged error message
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to patch virtual %s %s/%s: %v", b.config.Kind, vObj.GetNamespace(), vObj.GetName(), err)
+	}
+	if result == controllerutil.OperationResultUpdated || result == controllerutil.OperationResultUpdatedStatus || result == controllerutil.OperationResultUpdatedStatusOnly {
+		// a change will trigger reconciliation anyway, and at that point we can make
+		// a more accurate updates(reverse patches) to the virtual resource
+		return ctrl.Result{}, nil
+	}
+
+	// Execute reverse patches on physical object
+	_, err = executeObjectPatch(ctx.Context, ctx.PhysicalClient, vObj, func() error {
+		err = patches.ApplyPatches(pObj, vObj, b.config.ReversePatches, &virtualToHostNameResolver{namespace: vObj.GetNamespace()})
+		if err != nil {
+			return fmt.Errorf("error applying patches: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		if kerrors.IsInvalid(err) {
+			ctx.Log.Infof("Warning: this message could indicate a timing issue with no significant impact, or a bug. Please report this if your resource never reaches the expected state. Error message: failed to patch physical %s %s/%s: %v", b.config.Kind, pObj.GetNamespace(), pObj.GetName(), err)
+			// this happens when some field is being removed shortly after being added, which suggest it's a timing issue
+			// it doesn't seem to have any negative consequence besides the logged error message
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to patch physical %s %s/%s: %v", b.config.Kind, pObj.GetNamespace(), pObj.GetName(), err)
+	}
+
+	// ensure that the annotation with virtual name and namespace is present on the physical object
+	if !b.containsBackSyncNameAnnotations(pObj) {
+		err := b.addAnnotationsToPhysicalObject(ctx, pObj, vObj)
+		if err != nil {
+			if kerrors.IsInvalid(err) {
+				ctx.Log.Infof("Warning: this message could indicate a timing issue with no significant impact, or a bug. Please report this if your resource never reaches the expected state. Error message: failed to patch virtual %s %s/%s: %v", b.config.Kind, pObj.GetNamespace(), pObj.GetName(), err)
+				// this happens when some field is being removed shortly after being added, which suggest it's a timing issue
+				// it doesn't seem to have any negative consequence besides the logged error message
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+var _ syncer.UpSyncer = &backSyncController{}
+
+func (b *backSyncController) SyncUp(ctx *synccontext.SyncContext, pObj client.Object) (ctrl.Result, error) {
+	vNN := b.PhysicalToVirtual(pObj)
+	newObj := pObj.DeepCopyObject().(client.Object)
+	newObj.SetResourceVersion("")
+	newObj.SetUID("")
+	newObj.SetManagedFields([]metav1.ManagedFieldsEntry{})
+	newObj.SetNamespace(vNN.Namespace)
+	newObj.SetName(vNN.Name)
+
+	err := patches.ApplyPatches(newObj, newObj, b.config.Patches, &hostToVirtualNameResolver{namecache: b.namecache})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to apply declared patches to %s %s/%s: %v", b.config.Kind, newObj.GetNamespace(), newObj.GetName(), err)
+	}
+
+	ctx.Log.Infof("create virtual %s %s/%s", b.config.Kind, newObj.GetNamespace(), newObj.GetName())
+	err = ctx.VirtualClient.Create(ctx.Context, newObj)
+	if err != nil {
+		ctx.Log.Infof("error syncing %s %s/%s to virtual cluster: %v", b.config.Kind, newObj.GetNamespace(), newObj.GetName(), err)
+		b.EventRecorder().Eventf(newObj, "Warning", "SyncError", "Error syncing to virtual cluster: %v", err)
+		return ctrl.Result{}, err
+	}
+
+	// add annotation with virtual name and namespace on the physical object
+	err = b.addAnnotationsToPhysicalObject(ctx, pObj, newObj)
+	if err != nil {
+		if kerrors.IsInvalid(err) {
+			ctx.Log.Infof("Warning: this message could indicate a timing issue with no significant impact, or a bug. Please report this if your resource never reaches the expected state. Error message: failed to patch virtual %s %s/%s: %v", b.config.Kind, pObj.GetNamespace(), pObj.GetName(), err)
+			// this happens when some field is being removed shortly after being added, which suggest it's a timing issue
+			// it doesn't seem to have any negative consequence besides the logged error message
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (b *backSyncController) IsManaged(pObj client.Object) (bool, error) {
+	return true, nil
+}
+
+func (b *backSyncController) VirtualToPhysical(req types.NamespacedName, _ client.Object) types.NamespacedName {
+	// TODO: consider creating a simple local map to cache these translations,
+	// it would be populated from the PhysicalToVirtual()
+
+	var n string
+	for _, s := range b.config.Selectors {
+		if s.Name != nil {
+			n = b.parentNamecache.ResolveHostName(req, s.Name.RewrittenPath)
+		}
+
+		// TODO: implement other selector types here
+
+		if n != "" {
+			return types.NamespacedName{
+				Namespace: b.options.TargetNamespace,
+				Name:      n,
+			}
+		}
+	}
+
+	return types.NamespacedName{}
+}
+
+func (b *backSyncController) PhysicalToVirtual(pObj client.Object) types.NamespacedName {
+	if b.containsBackSyncNameAnnotations(pObj) {
+		pAnnotations := pObj.GetAnnotations()
+		return types.NamespacedName{
+			Namespace: pAnnotations[translator.NamespaceAnnotation],
+			Name:      pAnnotations[translator.NameAnnotation],
+		}
+	}
+
+	for _, s := range b.config.Selectors {
+		nn := types.NamespacedName{}
+		if s.Name != nil {
+			nn := b.parentNamecache.ResolveName(pObj.GetName(), s.Name.RewrittenPath)
+			if nn.Name == "" {
+				continue
+			}
+		}
+
+		// TODO: implement other selector types here
+		// if part of a selector does not match then we call `continue` to try different selector
+
+		if nn.Name != "" {
+			// if this selector matches then we don't evaluate other and return
+			return nn
+		}
+	}
+
+	return types.NamespacedName{}
+}
+
+var _ source.Source = &backSyncController{}
+
+func (b *backSyncController) Start(ctx context.Context, h handler.EventHandler, q workqueue.RateLimitingInterface, predicates ...predicate.Predicate) error {
+	// setup the necessary name cache hooks
+	for _, s := range b.config.Selectors {
+		if s.Name != nil {
+			b.parentNamecache.AddPathChangeHook(s.Name.RewrittenPath, func(nn types.NamespacedName) {
+				if nn.Name != "" {
+					q.Add(reconcile.Request{NamespacedName: nn})
+				}
+			})
+		}
+
+		// TODO: implement other selector types here
+
+	}
+	return nil
+}
+
+func (b *backSyncController) containsBackSyncNameAnnotations(obj client.Object) bool {
+	a := obj.GetAnnotations()
+	return a != nil && a[translate.MarkerLabel] == b.options.Name && a[translator.NameAnnotation] != "" && a[translator.NamespaceAnnotation] != ""
+}
+
+func (b *backSyncController) addAnnotationsToPhysicalObject(ctx *synccontext.SyncContext, pObj, vObj client.Object) error {
+	_, err := executeObjectPatch(ctx.Context, ctx.PhysicalClient, pObj, func() error {
+		annotations := pObj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[translate.MarkerLabel] = b.options.Name
+		annotations[translator.NameAnnotation] = vObj.GetName()
+		annotations[translator.NamespaceAnnotation] = vObj.GetNamespace()
+		pObj.SetAnnotations(annotations)
+		return nil
+	})
+	return err
+}

--- a/generic-crd-plugin/vendor/modules.txt
+++ b/generic-crd-plugin/vendor/modules.txt
@@ -128,7 +128,7 @@ github.com/json-iterator/go
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/vcluster-sdk v0.2.0
+# github.com/loft-sh/vcluster-sdk v0.3.0
 ## explicit; go 1.17
 github.com/loft-sh/vcluster-sdk/applier
 github.com/loft-sh/vcluster-sdk/clienthelper


### PR DESCRIPTION
I got the syncBack somewhat working - it will create a synced back resource when it is created in the host, and it will create it when the "parent" object is updated with the new value (e.g. .spec.secretName changes to reference different secret, which already exists, so the Secret watch would not be triggered, but the name cache hook will trigger it instead).

While fixing one issue with the Patches in Sync() I sort of broke it, so we need to fix that :sweat: 
I'll highlight the two next steps with a review comment.