### PR TITLE
chore: bump SDK version in cert-manager plugin

### DIFF
--- a/cert-manager-plugin/go.mod
+++ b/cert-manager-plugin/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/cert-manager/cert-manager v1.8.0
-	github.com/loft-sh/vcluster-sdk v0.3.2
+	github.com/loft-sh/vcluster-sdk v0.4.0
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/klog v1.0.0

--- a/cert-manager-plugin/go.sum
+++ b/cert-manager-plugin/go.sum
@@ -386,6 +386,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/loft-sh/vcluster-sdk v0.3.2 h1:uOwNO1W5dEPaBClmD5HdXoWr197+P0bWZrdpEUtc4OQ=
 github.com/loft-sh/vcluster-sdk v0.3.2/go.mod h1:HdQ75vqJuqiHiCtX+bmRAN9ZrCFimeYfQ5vKX1hEx2o=
+github.com/loft-sh/vcluster-sdk v0.4.0 h1:R5stbLwE1qAeqG6xIRXbPeHUQj8kuM2sNZ8PsIHQTM4=
+github.com/loft-sh/vcluster-sdk v0.4.0/go.mod h1:HdQ75vqJuqiHiCtX+bmRAN9ZrCFimeYfQ5vKX1hEx2o=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/cert-manager-plugin/plugin.yaml
+++ b/cert-manager-plugin/plugin.yaml
@@ -2,7 +2,7 @@
 # with the other vcluster values during vcluster create or helm install.
 plugin:
   cert-manager-plugin:
-    image: ghcr.io/loft-sh/vcluster-plugins/cert-manager-plugin:0.2.0
+    image: ghcr.io/loft-sh/vcluster-plugins/cert-manager-plugin:0.3.0
     imagePullPolicy: IfNotPresent
     rbac:
       role:

--- a/cert-manager-plugin/vendor/github.com/loft-sh/vcluster-sdk/translate/translate.go
+++ b/cert-manager-plugin/vendor/github.com/loft-sh/vcluster-sdk/translate/translate.go
@@ -51,12 +51,12 @@ func IsManaged(obj runtime.Object) bool {
 }
 
 func GetOwnerReference() []metav1.OwnerReference {
-	if Owner == nil {
+	if Owner == nil || Owner.GetName() == "" || Owner.GetUID() == "" {
 		return nil
 	}
 
 	typeAccessor, err := meta.TypeAccessor(Owner)
-	if err != nil {
+	if err != nil || typeAccessor.GetAPIVersion() == "" || typeAccessor.GetKind() == "" {
 		return nil
 	}
 

--- a/cert-manager-plugin/vendor/github.com/loft-sh/vcluster-sdk/translate/util/util.go
+++ b/cert-manager-plugin/vendor/github.com/loft-sh/vcluster-sdk/translate/util/util.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"github.com/loft-sh/vcluster-sdk/syncer/context"
+	"github.com/loft-sh/vcluster-sdk/translate"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+)
+
+// FindOwner finds the owner of the synced resources and sets it, unless SetOwner is set to false
+func FindOwner(ctx *context.RegisterContext) error {
+	if ctx.CurrentNamespace != ctx.Options.TargetNamespace {
+		if ctx.Options.SetOwner {
+			klog.Warningf("Skip setting owner, because current namespace %s != target namespace %s", ctx.CurrentNamespace, ctx.Options.TargetNamespace)
+		}
+		return nil
+	}
+
+	if ctx.Options.SetOwner {
+		service := &corev1.Service{}
+		err := ctx.CurrentNamespaceClient.Get(ctx.Context, types.NamespacedName{Namespace: ctx.CurrentNamespace, Name: ctx.Options.ServiceName}, service)
+		if err != nil {
+			return errors.Wrap(err, "get vcluster service")
+		}
+
+		translate.Owner = service
+		return nil
+	}
+
+	return nil
+}

--- a/cert-manager-plugin/vendor/modules.txt
+++ b/cert-manager-plugin/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/json-iterator/go
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/vcluster-sdk v0.3.2
+# github.com/loft-sh/vcluster-sdk v0.4.0
 ## explicit; go 1.17
 github.com/loft-sh/vcluster-sdk/applier
 github.com/loft-sh/vcluster-sdk/clienthelper
@@ -143,6 +143,7 @@ github.com/loft-sh/vcluster-sdk/syncer
 github.com/loft-sh/vcluster-sdk/syncer/context
 github.com/loft-sh/vcluster-sdk/syncer/translator
 github.com/loft-sh/vcluster-sdk/translate
+github.com/loft-sh/vcluster-sdk/translate/util
 # github.com/mailru/easyjson v0.7.6
 ## explicit; go 1.12
 github.com/mailru/easyjson/buffer


### PR DESCRIPTION
Bump SDK version in cert-manager plugin to [v0.4.0](https://github.com/loft-sh/vcluster-sdk/releases/tag/v0.4.0) and update tag in plugin.yaml ([new build](https://github.com/loft-sh/vcluster-plugins/pkgs/container/vcluster-plugins%2Fcert-manager-plugin/50929120?tag=0.3.0) was done with the code from this PR - with SDK version bump)