### PR TITLE
docs: fix confusing wording in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 This is the official vcluster Plugins Repository. Read more in the [vcluster documentation](https://www.vcluster.com/docs/plugins/overview).
 
-All Loft plugins have been vetted and approved by the Loft team.
-
-Loft Plugins:
+Plugins vetted and approved by the Loft Labs team:
 - [`cert-manager-plugin`](https://github.com/loft-sh/vcluster-plugins/tree/master/cert-manager-plugin): Reuse the host cluster's [cert-manager](https://cert-manager.io/docs/) inside vcluster. Syncs issuers and certificates to vcluster 
 
 


### PR DESCRIPTION
The original `Loft Plugins` statement sounds like it is a plugin to [Loft](loft.sh), which is not correct, thus this change to make it clear.